### PR TITLE
Basic arthimetic functions

### DIFF
--- a/Reduction.art
+++ b/Reduction.art
@@ -30,19 +30,19 @@
 -subL _E1,_sig -> _I1,_sigP                   --- sub(_E1,_E2),_sig -> sub(_I1,_E2),_sigP
 
 -mul _n1 |> __int32(_) _n2 |> __int32(_)      --- mul(_n1, _n2),_sig -> __mul(_n1, _n2),_sig
--mulR _n |> _int32(_) _E2,_sig -> _I2,_sigP   --- mul(_n,_E2),_sig -> mul(_n,_I2),_sigP
+-mulR _n |> __int32(_) _E2,_sig -> _I2,_sigP   --- mul(_n,_E2),_sig -> mul(_n,_I2),_sigP
 -mulL _E1,_sig -> _I1,_sigP                   --- mul(_E1, _E2),_sig -> mul(_I1, _E2),_sigP
 
 -add _n1 |> __int32(_) _n2 |> int32(_)        --- add(_n1, _n2),_sig -> __add(_n1, _n2),_sig
--addR _n |> _int32(_) _E2,_sig -> _I2,_sigP   --- add(_n,_E2),_sig -> add(_n,_I2),_sigP
+-addR _n |> __int32(_) _E2,_sig -> _I2,_sigP   --- add(_n,_E2),_sig -> add(_n,_I2),_sigP
 -addL _E1,_sig -> _I1,_sigP                   --- add(_E1, _E2),_sig -> add(_I1, _E2),_sigP
 
 -div _n1 |> __int32(_) _n2 |> int32(_)        --- div(_n1, _n2),_sig -> __div(_n1, _n2),_sig
--divR _n |> _int32(_) _E2,_sig -> _I2,_sigP   --- div(_n,_E2),_sig -> div(_n,_I2),_sigP
+-divR _n |> __int32(_) _E2,_sig -> _I2,_sigP   --- div(_n,_E2),_sig -> div(_n,_I2),_sigP
 -divL _E1,_sig -> _I1,_sigP                   --- div(_E1, _E2),_sig -> div(_I1, _E2),_sigP
 
 -mod _n1 |> __int32(_) _n2 |> int32(_)        --- mod(_n1, _n2),_sig -> __mod(_n1, _n2),_sig
--modR _n |> _int32(_) _E2,_sig -> _I2,_sigP   --- mod(_n,_E2),_sig -> mod(_n,_I2),_sigP
+-modR _n |> __int32(_) _E2,_sig -> _I2,_sigP   --- mod(_n,_E2),_sig -> mod(_n,_I2),_sigP
 -modL _E1,_sig -> _I1,_sigP                   --- mod(_E1, _E2),_sig -> mod(_I1, _E2),_sigP
 
 -plugin --- plugin(_O),_sig -> __plugin(_O),_sig

--- a/Reduction.art
+++ b/Reduction.art
@@ -29,6 +29,22 @@
 -subR _n |> __int32(_) _E2,_sig -> _I2,_sigP  --- sub(_n,_E2),_sig  -> sub(_n,_I2),_sigP
 -subL _E1,_sig -> _I1,_sigP                   --- sub(_E1,_E2),_sig -> sub(_I1,_E2),_sigP
 
+-mul _n1 |> __int32(_) _n2 |> __int32(_)      --- mul(_n1, _n2),_sig -> __mul(_n1, _n2),_sig
+-mulR _n |> _int32(_) _E2,_sig -> _I2,_sigP   --- mul(_n,_E2),_sig -> mul(_n,_I2),_sigP
+-mulL _E1,_sig -> _I1,_sigP                   --- mul(_E1, _E2),_sig -> mul(_I1, _E2),_sigP
+
+-add _n1 |> __int32(_) _n2 |> int32(_)        --- add(_n1, _n2),_sig -> __add(_n1, _n2),_sig
+-addR _n |> _int32(_) _E2,_sig -> _I2,_sigP   --- add(_n,_E2),_sig -> add(_n,_I2),_sigP
+-addL _E1,_sig -> _I1,_sigP                   --- add(_E1, _E2),_sig -> add(_I1, _E2),_sigP
+
+-div _n1 |> __int32(_) _n2 |> int32(_)        --- div(_n1, _n2),_sig -> __div(_n1, _n2),_sig
+-divR _n |> _int32(_) _E2,_sig -> _I2,_sigP   --- div(_n,_E2),_sig -> div(_n,_I2),_sigP
+-divL _E1,_sig -> _I1,_sigP                   --- div(_E1, _E2),_sig -> div(_I1, _E2),_sigP
+
+-mod _n1 |> __int32(_) _n2 |> int32(_)        --- mod(_n1, _n2),_sig -> __mod(_n1, _n2),_sig
+-modR _n |> _int32(_) _E2,_sig -> _I2,_sigP   --- mod(_n,_E2),_sig -> mod(_n,_I2),_sigP
+-modL _E1,_sig -> _I1,_sigP                   --- mod(_E1, _E2),_sig -> mod(_I1, _E2),_sigP
+
 -plugin --- plugin(_O),_sig -> __plugin(_O),_sig
 -plugin --- plugin(_O, _X),_sig -> __plugin(_O, _X),_sig
 -plugin --- plugin(_O, _X, _Y),_sig -> __plugin(_O, _X, _Y),_sig


### PR DESCRIPTION
Added basic arthmetic functions in the Reduction.Art file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core term-rewrite semantics for expression evaluation; mistakes in the new int32 coercions or operator handling could change runtime behavior for arithmetic-heavy programs.
> 
> **Overview**
> Adds new term-rewrite rules in `Reduction.art` for **basic arithmetic operators** (`mul`, `add`, `div`, `mod`), including both the direct int32 primitive reduction (e.g., `__mul`) and stepwise left/right evaluation rules for operands.
> 
> This expands the language’s reducible expression set beyond the existing comparisons/subtraction, potentially impacting evaluation order and numeric coercion for programs using these operators.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7c842bd39dcf4051aa6bca151b33108528a98c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->